### PR TITLE
Update config files so that it works on a clean install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build
 node_modules
 .grunt
+npm-debug.log
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
+# www.arthurblackdesign.com
+
 Just my design portfolio. It isn't much to see, yet.
+
+## Installation
+
+After you've installed [Node](http://nodejs.org/), clone this repository and install dependencies:
+
+```sh
+git clone https://github.com/rthrblack/arthurblackdesign && cd $_
+npm install
+```
+
+## Usage
+
+Start the server in development mode with `npm start` or in production mode with `npm test`.
+
+## Support
+
+Please [open an issue](https://github.com/rthrblck/arthurblackdesign/issues/new) for questions and concerns.
+
+## Contributing
+
+Fork this repository, commit your changes, and [open a pull request](https://github.com/rthrblck/arthurblackdesign/compare/).
+

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
     "type": "git",
     "url": "https://github.com/rthrblck/arthurblackdesign"
   },
+  "scripts": {
+    "start": "grunt",
+    "test": "grunt test",
+    "deploy": "grunt deploy"
+  },
   "dependencies": {
     "grunt": "~0.x.x",
     "grunt-autoprefixer": "^1.x.x",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "arthurblackdesign.com",
   "version": "0.0.1",
-  "devDependencies": {
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rthrblck/arthurblackdesign"
+  },
+  "dependencies": {
     "grunt": "~0.x.x",
     "grunt-autoprefixer": "^1.x.x",
     "grunt-contrib-clean": "^0.x.x",


### PR DESCRIPTION
I just wanted to throw together a pull request to make sure that everything works how it should on a clean install. Just to summarize what I did:
- I added `npm-debug.log` to the `.gitignore` since it's generated when NPM crashes, and shouldn't be part of the version history.
- I added your repository to the `package.json` so that NPM would stop bitching about it. I didn't do anything else, but you can see [the rest of the options](http://browsenpm.org/package.json) if you ever want to fill out package.json completely.
- I added [scripts](https://github.com/christianbundy/arthurblackdesign/blob/3443557afbbcd412aba86344481d7b881452503f/package.json#L8-12) to `package.json` so that you don't need to install Grunt globally to get everything up and running. This doesn't break the way you currently do things, but adds an option to use the `npm` tool that ships with Node instead of installing `grunt-cli`. Both `npm start` and `npm test` are [default scripts](https://www.npmjs.org/doc/misc/npm-scripts.html) that NPM knows how to deal with, but any custom ones (like "deploy") have to be run with `npm run deploy`. 
-  I added a quick-n-dirty README (with [README Boilerplate](https://github.com/fraction/readme-boilerplate)) with how everything works right now.

Eventually it might be cool to add a "Do you want to deploy?" [prompt](https://github.com/dylang/grunt-prompt) to the `test` Grunt task (so you don't have to have a separate `grunt deploy`/`npm run deploy`), but it works how it should right now.

P.S. It looks like there's some weird Gruntfile stuff going on with a clean install, but I'm assuming that will be solved by you reconfiguring your tasks to have separate folders. The commits in this pull request deal _only_ with your config files, so it shouldn't affect anything else.
