### PR TITLE
Fix foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Just my design portfolio. It isn't much to see, yet.
 After you've installed [Node](http://nodejs.org/), clone this repository and install dependencies:
 
 ```sh
-git clone https://github.com/rthrblack/arthurblackdesign && cd $_
+git clone https://github.com/rthrblck/arthurblackdesign
+cd arthurblackdesign
 npm install
 ```
 

--- a/src/index.html
+++ b/src/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Arthur Black Design</title>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/5.4.1/css/normalize.min.css"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/5.4.1/css/foundation.min.css"></script>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/foundation/5.4.4/css/foundation.min.css"/>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/normalize/3.0.1/normalize.min.css"/>
   <link rel="stylesheet" href="app.css"/>
 </head>
 

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -18,7 +18,7 @@
 	background-image: url(../img/simple_dashed.png);
 	background-repeat: repeat;
 	height: 100%;
-	padding-bottom: rem-calc(50px);
+	padding-bottom: calc(50px);
 	position: relative;
 	
 	.logo {
@@ -28,7 +28,7 @@
 
 .downArrow {
 	display: block;
-	max-width: rem-calc(25px);
+	max-width: calc(25px);
 	position: absolute;
 	top: 95%;
 	left: 50%;
@@ -56,7 +56,7 @@
 // PORTFOLIO
 
 .portfolio {
-	padding-bottom: rem-calc(40px);
+	padding-bottom: calc(40px);
 
 	.row {
 		@include maxWidthRow;
@@ -68,25 +68,25 @@
 }
 
 .portfolioPiece {
-	padding-top: rem-calc(40px);
+	padding-top: calc(40px);
 }
 
 .thumbnail {
 	background-image: url(../img/simple_dashed.png);
 	background-repeat: repeat;
-	padding-top: rem-calc(15px);
-	padding-bottom: rem-calc(15px);
+	padding-top: calc(15px);
+	padding-bottom: calc(15px);
 }
 
 .reveal {
 	background-image: url(../img/simple_dashed.png);
 	background-repeat: repeat;
 	color: white;
-	padding-top: rem-calc(40px);
+	padding-top: calc(40px);
 
 	.fullsize {
-		padding-top: rem-calc(20px);
-		padding-bottom: rem-calc(40px);
+		padding-top: calc(20px);
+		padding-bottom: calc(40px);
 	}
 }
 
@@ -98,16 +98,16 @@
 	background-image: url(../img/simple_dashed.png);
 	background-repeat: repeat;
 	color: white;
-	padding-top: rem-calc(40px);
-	padding-bottom: rem-calc(40px);
+	padding-top: calc(40px);
+	padding-bottom: calc(40px);
 
 	p {
-		margin-top: rem-calc(20px);
+		margin-top: calc(20px);
 	}
 }
 
 .headshot {
-	margin-top: rem-calc(20px);
+	margin-top: calc(20px);
 	
 	img {
 		border-radius: 50%;


### PR DESCRIPTION
This pull request resolves 3 problems:
1. We were using `<script>` tags for CSS (instead of `<link>`).
2. The original CDN [wasn't actually serving the right file](//cdnjs.cloudflare.com/ajax/libs/foundation/5.4.1/css/foundation.min.css), which is a bug on their end.
3. We were using [`rem-calc()`](https://github.com/zurb/foundation/blob/master/scss/foundation/_functions.scss#L79-89), which requires Foundation's SCSS. I've replaced these with [`calc()`](https://developer.mozilla.org/en-US/docs/Web/CSS/calc), which doesn't add any functionality, but shows you which units need to be converted to `rem` units.
